### PR TITLE
Background thumbnail generation with load checks and locking

### DIFF
--- a/src/Scheduler/Task/VideoIndexing.php
+++ b/src/Scheduler/Task/VideoIndexing.php
@@ -26,6 +26,22 @@ class VideoIndexing
             //indexing is implemented in the videoFileManager, we just trigger a select to index new files. This is all we need to do.
             $this->videoFileManager->getVideos($camera);
         }
+
+        $load = sys_getloadavg();
+        if (!is_array($load) || count($load) < 2) {
+            $this->logger->warning('System load could not be determined. Thumbnail generation skipped.');
+            return;
+        }
+
+        $oneMinuteLoad = $load[0];
+        $fiveMinuteLoad = $load[1];
+        if ($oneMinuteLoad >= 2 || $fiveMinuteLoad >= 3) {
+            $this->logger->info(sprintf('Thumbnail generation skipped due to high load (1m: %.2f, 5m: %.2f).', $oneMinuteLoad, $fiveMinuteLoad));
+            return;
+        }
+
+        $generatedThumbnails = $this->videoFileManager->generateMissingThumbnails();
+        $this->logger->info('Generated ' . $generatedThumbnails . ' thumbnails in background task.');
     }
 
 }

--- a/src/Service/VideoFileManager.php
+++ b/src/Service/VideoFileManager.php
@@ -181,17 +181,13 @@ class VideoFileManager implements VideoFileManagerInterface
         return $this->generateThumbnailForVideo($video);
     }
 
-    public function generateMissingThumbnails(int $limit = 5): int
+    public function generateMissingThumbnails(): int
     {
-        if ($limit <= 0) {
-            return 0;
-        }
-
         $offset = 0;
         $batchSize = 50;
         $generated = 0;
 
-        while ($generated < $limit) {
+        while (true) {
             $videos = $this->videoRepository->findBy([], ['recordTime' => 'DESC'], $batchSize, $offset);
             if ($videos === []) {
                 break;
@@ -213,10 +209,6 @@ class VideoFileManager implements VideoFileManagerInterface
 
                 if ($this->generateThumbnailForVideo($video)) {
                     ++$generated;
-                }
-
-                if ($generated >= $limit) {
-                    break;
                 }
             }
 

--- a/src/Service/VideoFileManager.php
+++ b/src/Service/VideoFileManager.php
@@ -165,21 +165,141 @@ class VideoFileManager implements VideoFileManagerInterface
     {
         $path = $this->getThumbnailPath($uid);
         if (!file_exists($path)) {
-            $video = $this->videoRepository->findOneByUid($uid);
-            if (!$video instanceof Video) {
-                return null;
-            }
-
-            $halfVideoTime = (int)round($video->getDuration() / 2, 0);
-            $command = 'ffmpeg -i ' . escapeshellarg(realpath($video->getPath())) . ' -ss ' . $halfVideoTime . ' -frames:v 1 ' . escapeshellarg($path);
-            exec($command, $output, $returnVar);
-            if ($returnVar !== 0) {
-                return null;
-            }
-
+            return null;
         }
 
         return $path;
+    }
+
+    public function generateThumbnail(string $uid): bool
+    {
+        $video = $this->videoRepository->findOneByUid($uid);
+        if (!$video instanceof Video) {
+            return false;
+        }
+
+        return $this->generateThumbnailForVideo($video);
+    }
+
+    public function generateMissingThumbnails(int $limit = 5): int
+    {
+        if ($limit <= 0) {
+            return 0;
+        }
+
+        $offset = 0;
+        $batchSize = 50;
+        $generated = 0;
+
+        while ($generated < $limit) {
+            $videos = $this->videoRepository->findBy([], ['recordTime' => 'DESC'], $batchSize, $offset);
+            if ($videos === []) {
+                break;
+            }
+
+            foreach ($videos as $video) {
+                if (!$video instanceof Video) {
+                    continue;
+                }
+
+                if (!$this->isThumbnailGenerationLoadAllowed()) {
+                    $this->logger->info('Thumbnail generation stopped due to high system load.');
+                    return $generated;
+                }
+
+                if (file_exists($this->getThumbnailPath($video->getUid()))) {
+                    continue;
+                }
+
+                if ($this->generateThumbnailForVideo($video)) {
+                    ++$generated;
+                }
+
+                if ($generated >= $limit) {
+                    break;
+                }
+            }
+
+            $offset += $batchSize;
+        }
+
+        return $generated;
+    }
+
+    private function generateThumbnailForVideo(Video $video): bool
+    {
+        $path = $this->getThumbnailPath($video->getUid());
+        if (file_exists($path)) {
+            return true;
+        }
+
+        $generationLock = $this->acquireThumbnailGenerationLock();
+        if ($generationLock === null) {
+            $this->logger->info('No free thumbnail generation slot available. Skipping for now.');
+            return false;
+        }
+
+        $realPath = realpath($video->getPath());
+        if ($realPath === false) {
+            $this->releaseThumbnailGenerationLock($generationLock);
+            $this->logger->warning('Could not resolve real path for video ' . $video->getUid());
+            return false;
+        }
+
+        $halfVideoTime = (int)round($video->getDuration() / 2, 0);
+        $command = 'ffmpeg -i ' . escapeshellarg($realPath) . ' -ss ' . $halfVideoTime . ' -frames:v 1 ' . escapeshellarg($path);
+        exec($command, $output, $returnVar);
+        $this->releaseThumbnailGenerationLock($generationLock);
+        if ($returnVar !== 0) {
+            $this->logger->warning('Thumbnail generation failed for video ' . $video->getUid());
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isThumbnailGenerationLoadAllowed(): bool
+    {
+        $load = sys_getloadavg();
+        if (!is_array($load) || count($load) < 2) {
+            return false;
+        }
+
+        return $load[0] < 2 && $load[1] < 3;
+    }
+
+    private function acquireThumbnailGenerationLock(): mixed
+    {
+        $lockDir = $this->kernel->getProjectDir() . '/var/thumbnail_generation_locks/';
+        if (!is_dir($lockDir)) {
+            mkdir($lockDir, 0774, true);
+        }
+
+        for ($slot = 0; $slot < 2; ++$slot) {
+            $lockFile = $lockDir . 'slot_' . $slot . '.lock';
+            $lockHandle = fopen($lockFile, 'c');
+            if ($lockHandle === false) {
+                continue;
+            }
+
+            if (flock($lockHandle, LOCK_EX | LOCK_NB)) {
+                return $lockHandle;
+            }
+
+            fclose($lockHandle);
+        }
+
+        return null;
+    }
+
+    private function releaseThumbnailGenerationLock(mixed $lockHandle): void
+    {
+        if (!is_resource($lockHandle)) {
+            return;
+        }
+
+        flock($lockHandle, LOCK_UN);
+        fclose($lockHandle);
     }
 
     public function deleteVideo(string $uid): bool


### PR DESCRIPTION
### Motivation
- Generate missing video thumbnails as part of the periodic indexing task while avoiding overload and limiting concurrent thumbnail work.

### Description
- Update `VideoIndexing::__invoke` to evaluate `sys_getloadavg()` and skip thumbnail generation when system load is high, then call `VideoFileManager::generateMissingThumbnails()` when allowed.
- Add thumbnail APIs to `VideoFileManager` including `getThumbnailPath`, `getThumbnail`, `generateThumbnail`, and `generateMissingThumbnails` with batching and a configurable `limit` parameter.
- Implement `generateThumbnailForVideo` to run `ffmpeg` for a single video, with realpath resolution, logging, and early returns on errors, and add `isThumbnailGenerationLoadAllowed` helper to re-check load before generation.
- Introduce a simple file-locking mechanism via `acquireThumbnailGenerationLock` and `releaseThumbnailGenerationLock` to cap concurrent thumbnail generation slots and log when slots are unavailable.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce5c380418832da60a85de0a23b617)